### PR TITLE
Naive fixes to some early encountered build problems

### DIFF
--- a/linc/linc_nanovg.xml
+++ b/linc/linc_nanovg.xml
@@ -19,6 +19,12 @@
 
     </files>
 
+    <files id="__main__">
+    	<compilerflag value='-I${LINC_NANOVG_PATH}/lib/nanovg/'/>
+        <compilerflag value='-I${LINC_NANOVG_PATH}/linc/'/>
+        <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/nanovg/src/"/>
+    </files>
+
     <target id="haxe">
 
         <section if="windows">

--- a/nanovg/Nvg.hx
+++ b/nanovg/Nvg.hx
@@ -9,6 +9,10 @@ import cpp.Float32;
 import stb.Image;
 #end
 
+#if (linc_opengl || linc_glew)
+import glew.GLEW;
+#end
+
 @:include("linc_nanovg.h")
 @:native("NVGcontext")
 extern class NvgContext {}

--- a/nanovg/Nvg.hx
+++ b/nanovg/Nvg.hx
@@ -5,6 +5,10 @@ import cpp.Pointer;
 import cpp.UInt8;
 import cpp.Float32;
 
+#if linc_stb
+import stb.Image;
+#end
+
 @:include("linc_nanovg.h")
 @:native("NVGcontext")
 extern class NvgContext {}


### PR DESCRIPTION
Adding `-lib linc_stb` is not enough to provide nanovg with its stb dependency, necessitating a poke at stb.Image somewhere to correct the build. The same is true for glew (not sure nanovg should be calling glew tbh but I guess it's no biggy).

Also added a files block for `__main__` because in some projects the lib was only included with the haxe group, resulting in missing files when building the executable.

TBH this was pretty frustrating and I'm not sure I've attacked the correct problems in the right way or order (even with the hxcpp guide the significance of groups and targets is not clear), but this finally got me back to work so.... feels better off sharing.